### PR TITLE
Role Creator Permissions

### DIFF
--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -4,17 +4,27 @@ namespace TorqIT\RoleCreatorBundle\Command;
 
 use Pimcore\Config;
 use Pimcore\Console\AbstractCommand;
+use Pimcore\Model\User\Permission\Definition;
 use Pimcore\Model\User\Role;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RoleCreatorCommand extends AbstractCommand
 {
+    private array $permissionKeys;
+
     protected function configure()
     {
         $this
             ->setName('torq:generate-roles')
             ->setDescription('Command for creating user roles in the pimcore admin interface.');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+
+        $this->permissionKeys = array_map(fn(Definition $d) => $d->getKey(),(new Definition\Listing())->load());
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -35,14 +45,37 @@ class RoleCreatorCommand extends AbstractCommand
 
     private function createRole($roleName, $roleProperties)
     {
-        $roleExists = Role::getByName($roleName);
-        if ($roleExists) {
-            return;
+        $role = Role::getByName($roleName);
+
+        if (!$role) {
+            $role = new Role();
         }
 
-        $newRole = new Role();
-        $newRole->setParentId(0);
-        $newRole->setName($roleName);
-        $newRole->save();
+        $this->applyPermissions($role, $roleProperties);
+
+        $role->setParentId(0);
+        $role->setName($roleName);
+        $role->save();
+    }
+
+    private function applyPermissions(Role $role, array $roleProperties)
+    {
+        if(key_exists("included_permissions", $roleProperties))
+        {
+            $nonExistentPermissions = array_diff($roleProperties["included_permissions"], $this->permissionKeys);
+
+            if(!empty($nonExistentPermissions))
+            {
+                $unrecognizedPermissions = implode(", ", $nonExistentPermissions);
+                $this->output->writeln("<comment>WARNING: Found unrecognized permissions ($unrecognizedPermissions)</comment>");
+            }
+
+            $role->setPermissions($roleProperties["included_permissions"]);
+        }
+        else if(key_exists("excluded_permissions", $roleProperties))
+        {
+            $targetPermissions = array_diff($this->permissionKeys, $roleProperties["excluded_permissions"]);
+            $role->setPermissions($targetPermissions);
+        }
     }
 }

--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -81,5 +81,9 @@ class RoleCreatorCommand extends AbstractCommand
         {
             $role->setPermissions($this->permissionKeys);
         }
+        else
+        {
+            $role->setPermissions([]);
+        }
     }
 }

--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -77,5 +77,9 @@ class RoleCreatorCommand extends AbstractCommand
             $targetPermissions = array_diff($this->permissionKeys, $roleProperties["excluded_permissions"]);
             $role->setPermissions($targetPermissions);
         }
+        else if(key_exists("all_permissions", $roleProperties))
+        {
+            $role->setPermissions($this->permissionKeys);
+        }
     }
 }


### PR DESCRIPTION
The Role creator can now assign permissions to a role via:
- `include_permissions` which includes specific permissions
- `excludes_permissions` which assigns all permissions _except_ for the ones listed
- `all_permissions` which enables all permissions