### PR TITLE
Assign DataObject/DocumentType Specific Creation Permission

### DIFF
--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -65,9 +65,9 @@ class RoleCreatorCommand extends AbstractCommand
             $this->output->writeln("Updating role: $roleName");
         }
 
-        $this->applyPermissions($role, $roleProperties);
-        $this->applyWorkspaces($role, $roleProperties);
-        $this->applyAllowedTypes($role, $roleProperties);
+        $this->applyPermissions($role, $roleProperties ?? []);
+        $this->applyWorkspaces($role, $roleProperties ?? []);
+        $this->applyAllowedTypes($role, $roleProperties ?? []);
 
         $role->setParentId(0);
         $role->setName($roleName);

--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -67,8 +67,7 @@ class RoleCreatorCommand extends AbstractCommand
 
         $this->applyPermissions($role, $roleProperties);
         $this->applyWorkspaces($role, $roleProperties);
-
-
+        $this->applyAllowedTypes($role, $roleProperties);
 
         $role->setParentId(0);
         $role->setName($roleName);

--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -4,10 +4,13 @@ namespace TorqIT\RoleCreatorBundle\Command;
 
 use Pimcore\Config;
 use Pimcore\Console\AbstractCommand;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\Document\DocType;
 use Pimcore\Model\User\Permission\Definition;
 use Pimcore\Model\User\Role;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Config\Pimcore\ConfigLocation\DocumentTypesConfig;
 use TorqIT\RoleCreatorBundle\Service\WorkspaceBuilder;
 
 class RoleCreatorCommand extends AbstractCommand
@@ -64,6 +67,8 @@ class RoleCreatorCommand extends AbstractCommand
 
         $this->applyPermissions($role, $roleProperties);
         $this->applyWorkspaces($role, $roleProperties);
+
+
 
         $role->setParentId(0);
         $role->setName($roleName);
@@ -142,5 +147,64 @@ class RoleCreatorCommand extends AbstractCommand
 
             $role->setWorkspacesDocument($documentWorkspaces);
         }
+    }
+
+    private function applyAllowedTypes(Role $role, array $roleProperties)
+    {
+        if(!key_exists("allowedTypes", $roleProperties))
+        {
+            return;
+        }
+
+        $allowedTypes = $roleProperties["allowedTypes"];
+
+        if(key_exists("classes", $allowedTypes) && is_array($allowedTypes["classes"]))
+        {
+            $allowedClasses = [];
+
+            foreach($allowedTypes["classes"] as $className)
+            {
+                $classDef = ClassDefinition::getByName($className);
+
+                if($classDef)
+                {
+                    $allowedClasses[] = $classDef->getId();
+                }
+            }
+
+            $role->setClasses($allowedClasses);
+        }
+
+        if(key_exists("document_types", $allowedTypes) && is_array($allowedTypes["document_types"]))
+        {
+            $allowedDocs = [];
+            $docTypes = (new DocType\Listing())->load();
+
+            foreach($allowedTypes["document_types"] as $docName)
+            {
+                $docType = $this->findDocWithName($docName, $docTypes);
+
+                if($docType)
+                {
+                    $allowedDocs[] = $docType->getId();
+                }
+            }
+
+            $role->setDocTypes($allowedDocs);
+        }
+    }
+
+    /** @param DocType[] $docTypes */
+    private function findDocWithName(string $name, array $docTypes)
+    {
+        foreach($docTypes as $docType)
+        {
+            if($docType->getName() == $name)
+            {
+                return $docType;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -153,6 +153,8 @@ class RoleCreatorCommand extends AbstractCommand
     {
         if(!key_exists("allowedTypes", $roleProperties))
         {
+            $role->setClasses([]);
+            $role->setDocTypes([]);
             return;
         }
 
@@ -174,6 +176,9 @@ class RoleCreatorCommand extends AbstractCommand
 
             $role->setClasses($allowedClasses);
         }
+        else {
+            $role->setClasses([]);
+        }
 
         if(key_exists("document_types", $allowedTypes) && is_array($allowedTypes["document_types"]))
         {
@@ -191,6 +196,9 @@ class RoleCreatorCommand extends AbstractCommand
             }
 
             $role->setDocTypes($allowedDocs);
+        }
+        else {
+            $role->setDocTypes([]);
         }
     }
 


### PR DESCRIPTION
The role creator can now assign data object/document type specific permissions via the following syntax (per role)
```yaml
allowed_types:
  classes: ["ClassName", "OtherClassName"]
  document_types: ["Doc Type Name", "Other Doc Type Name"]
```