### PR TITLE
Bugfix: Load class definition by id

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "torqit/pimcore-role-creator-bundle",
     "type": "pimcore-bundle",
     "require": {
-        "pimcore/pimcore": "^12.0"
+        "pimcore/pimcore": "^11.0 || ^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/RoleCreatorCommand.php
+++ b/src/Command/RoleCreatorCommand.php
@@ -146,7 +146,7 @@ class RoleCreatorCommand extends AbstractCommand
             $allowedClasses = [];
 
             foreach ($allowedTypes["classes"] as $className) {
-                $classDef = ClassDefinition::getByName($className);
+                $classDef = ClassDefinition::getById($className);
 
                 if ($classDef) {
                     $allowedClasses[] = $classDef->getId();


### PR DESCRIPTION
- Event listener saves the class id to the .yaml file, so the create role command needs to load classes by id


Closes PIM-2023